### PR TITLE
Restore original v3.1.2 code.

### DIFF
--- a/libsrc/wrapper.c
+++ b/libsrc/wrapper.c
@@ -411,7 +411,7 @@ void Listen(int s, int backlog)
         unix_error("Listen error");
 }
 
-int Accept(int s, struct sockaddr *addr, socklen_t *addrlen) 
+int Accept(int s, struct sockaddr *addr, int *addrlen) 
 {
     int rc;
 

--- a/libsrc/wrapper.h
+++ b/libsrc/wrapper.h
@@ -128,7 +128,7 @@ int Socket(int domain, int type, int protocol);
 void Setsockopt(int s, int level, int optname, const void *optval, int optlen);
 void Bind(int sockfd, struct sockaddr *my_addr, int addrlen);
 void Listen(int s, int backlog);
-int Accept(int s, struct sockaddr *addr, socklen_t *addrlen);
+int Accept(int s, struct sockaddr *addr, int *addrlen);
 void Connect(int sockfd, struct sockaddr *serv_addr, int addrlen);
 
 /* DNS wrappers */


### PR DESCRIPTION
Restore code to original v3.1.2 state by removing fixes in `libsrc/wrapper.*` that eliminated compiler warnings.